### PR TITLE
Run page updates

### DIFF
--- a/client/src/pages/Run.js
+++ b/client/src/pages/Run.js
@@ -195,7 +195,7 @@ function Run() {
             {orders.length > 0 ? orders : <h3>&emsp; No participants yet</h3>}
 
             <h3>My Meal:</h3>
-            {userIsInRun ? <MealBox orderID={myMeal.orderID} orderName={myMeal.orderName ? myMeal.orderName : "Meal Name"} listOfItems={myMeal.orderItems} /> : false}
+            {userIsInRun ? <MealBox runStatus={status} orderID={myMeal.orderID} orderName={myMeal.orderName ? myMeal.orderName : "Meal Name"} listOfItems={myMeal.orderItems} /> : false}
 
             {!userIsInRun && status === "started" ? <Button type="button" buttonSize="btn-lg" onClick={addUserToRun} >Add Me To Run!</Button> : false}
 

--- a/client/src/pages/Run.js
+++ b/client/src/pages/Run.js
@@ -141,10 +141,50 @@ function Run() {
             });
     }
 
+    function updateStatus() {
+        let newStatus = "ordered";
+        switch(status) {
+            case "ordered":
+                newStatus = "pickedUp";
+                break;
+            case "pickedUp":
+                newStatus = "delivered";
+                break;
+            case "delivered":
+                newStatus = "completed";
+                break;
+        }
+
+        const d = new Date();
+        const newTime = d.getHours() + ":" + d.getMinutes();
+        API.updateRun(id,
+            {
+                status: newStatus,
+                time: newTime
+            })
+            .then((res) => {
+                window.location.reload();
+            })
+    }
+
+    // Decide which type of button to display at bottom
+    let updateStatusButtonText = "Place Order";
+    switch(status){
+        case "ordered":
+            updateStatusButtonText = "Picked Up";
+            break;
+        case "pickedUp":
+            updateStatusButtonText = "Mark Delivered";
+            break;
+        case "delivered":
+            updateStatusButtonText = "Mark Completed";
+            break;
+    }
+
     return (
         <div>
             <RestaurantBox restaurant_name={restaurant_name} address={restaurant_address} run_id={id} />
-            <StatusBar status={status} time={time} />
+            { status != "completed" ? <StatusBar status={status} time={time} /> : false}
             <h3><a id="inviteLink"
                 href={window.location.hostname + ":" + window.location.port + "/run/" + id}
                 onClick={copyToClipboard}
@@ -159,11 +199,8 @@ function Run() {
 
             {!userIsInRun && status === "started" ? <Button type="button" buttonSize="btn-lg" onClick={addUserToRun} >Add Me To Run!</Button> : false}
 
-            {isRunner && status === "started" && orders.length > 0 ? <h3>Place Order</h3> : false}
-            {isRunner && status === "ordered" ? <h3>Picked Up</h3> : false}
-            {isRunner && status === "pickedUp" ? <h3>Mark Delivered</h3> : false}
-            {isRunner && status === "delivered" ? <h3>Mark Completed</h3> : false}
-            {isRunner && status === "completed" ? <h3>Completed!</h3> : false}
+            {isRunner && status != "completed" ? <Button type="button" buttonSize="btn-lg" onClick={updateStatus} >{updateStatusButtonText}</Button> : false}
+            {status === "completed" ? <h3>Completed!</h3> : false}
         </div>
     );
 }

--- a/models/order.js
+++ b/models/order.js
@@ -22,8 +22,8 @@ const orderSchema = new Schema({
     },
     status: {
         type: String,
-        enum: ['Waiting for meal','Meal placed', 'Meal Payed'],
-        default: 'Waiting for meal'
+        enum: ['waiting','placed', 'payed'],
+        default: 'waiting'
     },
     timesOrdered: {
         type: Number,


### PR DESCRIPTION
From the run page, the runner can now update the status of a run from started to ordered to pickedUp to delivered to  completed. This also updates the runs time, which is used to keep track of when the status last changed.

In addition, a user can finalize their order by clicking the "Place Order" button, which changes the order's status from waiting to placed. To do after bootcamp is over: Make it so runner can update an order from placed to payed (not 100% necessary right now).